### PR TITLE
glTF support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": true,
     "python.formatting.provider": "autopep8",
-    "python.formatting.autopep8Args": ["--max-line-length=120"],
+    "python.formatting.autopep8Args": [
+        "--max-line-length=120"
+    ],
     "autoDocstring.docstringFormat": "sphinx"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     "python.formatting.autopep8Args": [
         "--max-line-length=120"
     ],
-    "autoDocstring.docstringFormat": "sphinx"
+    "autoDocstring.docstringFormat": "sphinx",
+    "python.pythonPath": "d:\\Programs\\Scoop\\apps\\blender\\current\\2.83\\python\\bin\\python.exe"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,6 @@
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": true,
     "python.formatting.provider": "autopep8",
-    "python.formatting.autopep8Args": [
-        "--max-line-length=120"
-    ],
-    "autoDocstring.docstringFormat": "sphinx",
-    "python.pythonPath": "d:\\Programs\\Scoop\\apps\\blender\\current\\2.83\\python\\bin\\python.exe"
+    "python.formatting.autopep8Args": ["--max-line-length=120"],
+    "autoDocstring.docstringFormat": "sphinx"
 }

--- a/exporter/constants.py
+++ b/exporter/constants.py
@@ -39,3 +39,12 @@ EXPORT_FILE_TYPES = {
     MID_POLY_TYPE: "OBJ",
     HIGH_POLY_TYPE: "OBJ",
 }
+
+# Export type to format mappings (glTF)
+# TODO: find a more modular solution
+EXPORT_FILE_TYPES_GLTF = {
+    STATIC_MESH_TYPE: "GLB",
+    SKELETAL_MESH_TYPE: "GLB",
+    MID_POLY_TYPE: "OBJ",
+    HIGH_POLY_TYPE: "OBJ",
+}

--- a/exporter/constants.py
+++ b/exporter/constants.py
@@ -30,12 +30,3 @@ EXPORT_TYPES = [
     (MID_POLY_TYPE, "Mid Poly", "Mid Poly", 'MESH', 3),
     (HIGH_POLY_TYPE, "High Poly", "High Poly", 'MESH', 4),
 ]
-
-
-# Export type to format mappings
-EXPORT_FILE_TYPES = {
-    STATIC_MESH_TYPE: "FBX",
-    SKELETAL_MESH_TYPE: "FBX",
-    MID_POLY_TYPE: "OBJ",
-    HIGH_POLY_TYPE: "OBJ",
-}

--- a/exporter/constants.py
+++ b/exporter/constants.py
@@ -39,12 +39,3 @@ EXPORT_FILE_TYPES = {
     MID_POLY_TYPE: "OBJ",
     HIGH_POLY_TYPE: "OBJ",
 }
-
-# Export type to format mappings (glTF)
-# TODO: find a more modular solution
-EXPORT_FILE_TYPES_GLTF = {
-    STATIC_MESH_TYPE: "GLB",
-    SKELETAL_MESH_TYPE: "GLB",
-    MID_POLY_TYPE: "OBJ",
-    HIGH_POLY_TYPE: "OBJ",
-}

--- a/exporter/export_collection.py
+++ b/exporter/export_collection.py
@@ -7,8 +7,14 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Collection, Object
 from . import constants
-from ..utils import get_source_path, get_preferences
-from ..utils.functions import get_export_extension, get_export_method, export_gltf, export_fbx, export_obj, remove_numeric_suffix, SceneState, unlink_collection
+from ..utils import get_source_path
+from ..utils.functions import (
+    get_export_extension,
+    get_export_method,
+    remove_numeric_suffix,
+    SceneState,
+    unlink_collection,
+)
 
 
 RELATIVE_ROOT = ".\\"

--- a/exporter/export_collection.py
+++ b/exporter/export_collection.py
@@ -23,8 +23,8 @@ RELATIVE_ROOT = ".\\"
 def get_export_filename(export_name, export_type, include_extension=True):
     """Gets a preview of the export filename based on `export_name` and `export_type`."""
     export_name = validate_export_name(export_name)
-    extension = get_export_extension(export_type).lower() if include_extension else ""
-    return f"{export_type}_{export_name}.{extension}"
+    extension = ("." + get_export_extension(export_type).lower()) if include_extension else ""
+    return f"{export_type}_{export_name}{extension}"
 
 
 def validate_export_name(export_name):

--- a/exporter/export_collection.py
+++ b/exporter/export_collection.py
@@ -7,8 +7,8 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Collection, Object
 from . import constants
-from ..utils import get_source_path
-from ..utils.functions import export_fbx, export_obj, remove_numeric_suffix, SceneState, unlink_collection
+from ..utils import get_source_path, get_preferences
+from ..utils.functions import export_gltf, export_fbx, export_obj, remove_numeric_suffix, SceneState, unlink_collection
 
 
 RELATIVE_ROOT = ".\\"
@@ -17,7 +17,8 @@ RELATIVE_ROOT = ".\\"
 def get_export_filename(export_name, export_type, include_extension=True):
     """Gets a preview of the export filename based on `export_name` and `export_type`."""
     export_name = validate_export_name(export_name)
-    extension = f".{constants.EXPORT_FILE_TYPES[export_type].lower()}" if include_extension else ""
+    file_types = constants.EXPORT_FILE_TYPES_GLTF if get_preferences().use_gltf else constants.EXPORT_FILE_TYPES
+    extension = f".{file_types[export_type].lower()}" if include_extension else ""
     if export_type in [constants.MID_POLY_TYPE, constants.HIGH_POLY_TYPE]:
         return f"{export_name}_{export_type}{extension}"
     return f"{export_type}_{export_name}{extension}"
@@ -173,7 +174,7 @@ class ExportCollection(Collection):
             print(f"Created new folder: {target_folder}")
 
         # Export the contents of the Collection as appropriate
-        export_method = export_fbx
+        export_method = export_gltf if get_preferences().use_gltf else export_fbx
         if self.export_type in [constants.MID_POLY_TYPE, constants.HIGH_POLY_TYPE]:
             export_method = export_obj
 

--- a/exporter/export_collection.py
+++ b/exporter/export_collection.py
@@ -47,7 +47,8 @@ def validate_export_name(export_name):
         new_tokens.append(path.splitext(path.basename(bpy.data.filepath))[0])
 
     # Strip type prefix if someone typed it in manually
-    if new_tokens[0].upper() in constants.EXPORT_FILE_TYPES.keys():
+    prefixes = [export_type[0] for export_type in constants.EXPORT_TYPES]
+    if new_tokens[0].upper() in prefixes:
         if len(new_tokens) == 1:
             export_name = path.splitext(path.basename(bpy.data.filepath))[0]
         else:

--- a/exporter/export_collection.py
+++ b/exporter/export_collection.py
@@ -176,9 +176,8 @@ class ExportCollection(Collection):
         result = {'CANCELLED'}
         try:
             result = export_method(export_path)
-        except Exception as e:  # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             print(f"Error occurred while trying to export '{self.name}'. See System Console for details.")
-            print(e)
 
         self._post_export(origin_objects)
         state.restore()

--- a/exporter/operators/new_export_collection.py
+++ b/exporter/operators/new_export_collection.py
@@ -6,6 +6,7 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Operator
 from .. import constants
+from ...utils import get_preferences
 from ..export_collection import get_export_filename
 from ..functions import check_path, create_export_collection
 
@@ -73,6 +74,7 @@ class EmbarkNewExportCollection(Operator):
             name_content.append(bpy.context.active_object.name)
         export_name = "_".join(name_content)
         self.filename = get_export_filename(export_name, self.export_type)
+        self.filter_glob = "*.glb;*.obj" if get_preferences().use_gltf else "*.fbx;*.obj"
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 

--- a/exporter/operators/new_export_collection.py
+++ b/exporter/operators/new_export_collection.py
@@ -7,6 +7,7 @@ from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Operator
 from .. import constants
 from ...utils import get_preferences
+from ...utils.functions import get_export_filter_glob
 from ..export_collection import get_export_filename
 from ..functions import check_path, create_export_collection
 
@@ -74,7 +75,7 @@ class EmbarkNewExportCollection(Operator):
             name_content.append(bpy.context.active_object.name)
         export_name = "_".join(name_content)
         self.filename = get_export_filename(export_name, self.export_type)
-        self.filter_glob = "*.glb;*.obj" if get_preferences().use_gltf else "*.fbx;*.obj"
+        self.filter_glob = get_export_filter_glob()
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 

--- a/exporter/operators/new_export_collection.py
+++ b/exporter/operators/new_export_collection.py
@@ -22,7 +22,7 @@ class EmbarkNewExportCollection(Operator):
     def _export_type_changed(self, context):
         """Updates the file browser type filter and file extension when the Export Type is changed."""
         # BUG: Dynamically changing the file browser properties appears to not be currently supported in Blender :(
-        self.filter_glob = f"*.{constants.EXPORT_FILE_TYPES[self.export_type].lower()}"
+        self.filter_glob = get_export_filter_glob()
         self.filename = get_export_filename(self.export_name, self.export_type)
 
     directory: StringProperty()

--- a/exporter/operators/new_export_collection.py
+++ b/exporter/operators/new_export_collection.py
@@ -6,7 +6,7 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Operator
 from .. import constants
-from ...utils.functions import get_export_filter_glob
+from ...utils.functions import get_export_extension, get_export_filter_glob
 from ..export_collection import get_export_filename
 from ..functions import check_path, create_export_collection
 
@@ -39,7 +39,7 @@ class EmbarkNewExportCollection(Operator):
     def draw(self, context):
         """Draws the Operator properties."""
         self.layout.prop(self, constants.PROP_EXPORT_TYPE, expand=True)
-        self.layout.label(text=f"Exports in {constants.EXPORT_FILE_TYPES[self.export_type]} format")
+        self.layout.label(text=f"Exports in {get_export_extension(self.export_type)} format")
         self.layout.prop(self, "export_immediately")
 
     def execute(self, context):

--- a/exporter/operators/new_export_collection.py
+++ b/exporter/operators/new_export_collection.py
@@ -6,7 +6,6 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Operator
 from .. import constants
-from ...utils import get_preferences
 from ...utils.functions import get_export_filter_glob
 from ..export_collection import get_export_filename
 from ..functions import check_path, create_export_collection

--- a/exporter/operators/new_export_collections_per_object.py
+++ b/exporter/operators/new_export_collections_per_object.py
@@ -5,7 +5,7 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy.types import Operator
 from .. import constants
-from ..export_collection import get_export_filename
+from ..export_collection import get_export_extension, get_export_filename
 from ..functions import check_path, create_export_collection
 from ...utils.functions import remove_numeric_suffix
 
@@ -80,7 +80,7 @@ class EmbarkNewExportCollectionsPerObject(Operator):
     def draw(self, context):
         """Draws the Operator properties."""
         self.layout.prop(self, constants.PROP_EXPORT_TYPE, expand=True)
-        self.layout.label(text=f"Exports in {constants.EXPORT_FILE_TYPES[self.export_type]} format")
+        self.layout.label(text=f"Exports in {get_export_extension(self.export_type)} format")
         self.layout.prop(self, "use_object_origin")
         self.layout.prop(self, "export_immediately")
 

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -74,7 +74,6 @@ def export_gltf(filepath, export_format):
     return bpy.ops.export_scene.gltf(
         export_format=export_format,
         export_copyright="",
-        export_image_format='AUTO',
         export_texcoords=True,
         export_normals=True,
         export_draco_mesh_compression_enable=False,

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -32,6 +32,48 @@ class SceneState():  # pylint: disable=too-few-public-methods
             bpy.context.view_layer.objects.active = self.edit_object
 
 
+def export_gltf(filepath):
+    """Export a glTF with standardized settings."""
+    return bpy.ops.export_scene.gltf(
+        export_format='GLB',
+        ui_tab='GENERAL',
+        export_copyright="",
+        export_image_format='PNG',
+        export_texcoords=True,
+        export_normals=True,
+        export_draco_mesh_compression_enable=False,
+        export_draco_mesh_compression_level=6,
+        export_draco_position_quantization=14,
+        export_draco_normal_quantization=10,
+        export_draco_texcoord_quantization=12,
+        export_tangents=False,
+        export_materials=True,
+        export_colors=True,
+        export_cameras=False,
+        export_selected=True,
+        export_extras=False,
+        export_yup=True,
+        export_apply=True,
+        export_animations=True,
+        export_frame_range=True,
+        export_frame_step=1,
+        export_force_sampling=True,
+        export_nla_strips=True,
+        export_current_frame=False,
+        export_skins=True,
+        export_all_influences=False,
+        export_morph=True,
+        export_morph_normal=True,
+        export_morph_tangent=False,
+        export_lights=False,
+        export_displacement=False,
+        will_save_settings=False,
+        filepath=filepath,
+        check_existing=False,
+        filter_glob="*.glb;*.gltf",
+    )
+
+
 def export_fbx(filepath):
     """Export an FBX with standardized settings."""
     return bpy.ops.export_scene.fbx(

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -5,7 +5,6 @@ from os import environ, path
 from bpy.props import BoolProperty, StringProperty, EnumProperty
 from bpy.types import AddonPreferences
 from . import ADDON_NAME
-from .functions import get_export_extension, get_export_method, get_export_filter_glob
 
 BLENDER_TOOLS_SOURCE_PATH = "BLENDER_TOOLS_SOURCE_PATH"
 

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -41,6 +41,11 @@ class EmbarkAddonPreferences(AddonPreferences):  # pylint: disable=too-few-publi
         description="If enabled, the addon will check for updates on each session launch (may add loading time)",
         default=True,
     )
+    use_gltf: BoolProperty(
+        name="Use glTF",
+        description="If enabled, the addon will use glTF when exporting meshes",
+        default=False,
+    )
     source_path: StringProperty(
         name="Project source folder",
         description="Location of raw source files for your project, used as a root for scene & import/export paths",
@@ -52,6 +57,7 @@ class EmbarkAddonPreferences(AddonPreferences):  # pylint: disable=too-few-publi
     def draw(self, context):
         """Draws the preferences."""
         self.layout.prop(self, 'auto_update', expand=True)
+        self.layout.prop(self, 'use_gltf', expand=True)
         self.layout.prop(self, 'source_path', expand=True)
 
     def set_items(self, items):

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -2,9 +2,10 @@
 
 
 from os import environ, path
-from bpy.props import BoolProperty, StringProperty
+from bpy.props import BoolProperty, StringProperty, EnumProperty
 from bpy.types import AddonPreferences
 from . import ADDON_NAME
+from .functions import get_export_extension, get_export_method, get_export_filter_glob
 
 BLENDER_TOOLS_SOURCE_PATH = "BLENDER_TOOLS_SOURCE_PATH"
 
@@ -41,10 +42,15 @@ class EmbarkAddonPreferences(AddonPreferences):  # pylint: disable=too-few-publi
         description="If enabled, the addon will check for updates on each session launch (may add loading time)",
         default=True,
     )
-    use_gltf: BoolProperty(
-        name="Use glTF",
-        description="If enabled, the addon will use glTF when exporting meshes",
-        default=False,
+    export_file_type: EnumProperty(
+        items=[
+            ('FBX', 'FBX', ''),
+            ('GLTF', 'GLTF', 'Separated GLTF'),
+            ('GLB', 'GLB', ''),
+        ],
+        name="Export File Type",
+        description="Determines which file type will be used when exporting static and skeletal meshes.",
+        default=None,
     )
     source_path: StringProperty(
         name="Project source folder",
@@ -57,7 +63,7 @@ class EmbarkAddonPreferences(AddonPreferences):  # pylint: disable=too-few-publi
     def draw(self, context):
         """Draws the preferences."""
         self.layout.prop(self, 'auto_update', expand=True)
-        self.layout.prop(self, 'use_gltf', expand=True)
+        self.layout.prop(self, 'export_file_type')
         self.layout.prop(self, 'source_path', expand=True)
 
     def set_items(self, items):


### PR DESCRIPTION
Quick and dirty implementation of glTF support (#2).
Adds a `Use glTF` option in preferences which will replace FBX with glTF.

There's a couple of `if get_preferences().use_gltf else` in there which makes the code base harder to maintain but this should suffice for a starting point and discussion.