### PR TITLE
Fix exporter on non-windows operating systems

### DIFF
--- a/exporter/export_collection.py
+++ b/exporter/export_collection.py
@@ -11,7 +11,7 @@ from ..utils import get_source_path
 from ..utils.functions import export_fbx, export_obj, remove_numeric_suffix, SceneState, unlink_collection
 
 
-RELATIVE_ROOT = ".\\"
+RELATIVE_ROOT = "./"
 
 
 def get_export_filename(export_name, export_type, include_extension=True):


### PR DESCRIPTION
The root directory path is hardcoded to a backslash currently, which breaks support on non-windows operating systems. This replaces that with a forward slash, which should work on all operating systems. see #4.