### PR TITLE
Speculative fix for a startup race condition, get_preferences() might not be ready yet

### DIFF
--- a/operators/update.py
+++ b/operators/update.py
@@ -223,7 +223,8 @@ class CheckForUpdates(bpy.types.Operator):
 @persistent
 def _auto_update_handler(context):
     """Check for updates on first scene load."""
-    bpy.ops.screen.embark_check_for_updates()
+    if get_preferences().auto_update is True:
+        bpy.ops.screen.embark_check_for_updates()
     bpy.app.handlers.load_post.remove(_auto_update_handler)  # Job done, so remove itself
 
 
@@ -242,9 +243,8 @@ def register():
     for cls in __classes__:
         bpy.utils.register_class(cls)
 
-    # Add a scene load handler for the first time auto-update check, if needed
-    if get_preferences().auto_update is True:
-        bpy.app.handlers.load_post.append(_auto_update_handler)
+    # Add a scene load handler for the first time auto-update check
+    bpy.app.handlers.load_post.append(_auto_update_handler)
 
 
 def unregister():


### PR DESCRIPTION
Relates to #8, I managed to hit this issue a couple of times on startup too, before making this change.

What I believe is happening:
1. Addon begins `__init__` and starts registering modules
2. `update` module is registered, during which it calls `get_preferences()` which tries to get the addon prefs immediately
3. If you're lucky, the addon is already registered with Blender at this point, and `get_preferences()` works - if you're not lucky, the addon isn't fully registered yet, so `get_preferences()` fails and errors, causing the entire addon to fail loading

By moving the actual check into the post-load script, we avoid this potential race condition.

After this change, I was not able to reproduce the issue at all despite a large number of full reloads/restarts of Blender.